### PR TITLE
Fix AttributeError problem when using DatabaseTestCase in functional tests

### DIFF
--- a/src/pyramid_sqlalchemy/testing.py
+++ b/src/pyramid_sqlalchemy/testing.py
@@ -10,6 +10,15 @@ from pyramid_sqlalchemy import Session
 import transaction
 
 
+def enable_sql_two_phase_commit_test(config, enable=True):
+    """Fake enable_sql_two_phase_commit function used in the tests."""
+
+
+def includeme_test(config):
+    """Fake includeme function that replaces the real one in the tests."""
+    config.add_directive('enable_sql_two_phase_commit', enable_sql_two_phase_commit_test)
+
+
 class DatabaseTestCase(unittest.TestCase):
     """Base class for tests which require a database connection.
 
@@ -35,7 +44,7 @@ class DatabaseTestCase(unittest.TestCase):
         if self.create_tables:
             metadata.create_all()
         super(DatabaseTestCase, self).setUp()
-        self._sqlalchemy_patcher = mock.patch('pyramid_sqlalchemy.includeme')
+        self._sqlalchemy_patcher = mock.patch('pyramid_sqlalchemy.includeme', includeme_test)
         self._sqlalchemy_patcher.start()
 
     def tearDown(self):


### PR DESCRIPTION
The patched pyramid_sqlalchemy.includeme function was not working when
Pyramid was trying to invoke it. This change uses an API compatible
includeme function that does not do anything but allows the functional
tests to proceed without raising an AttributeError.

This is the exception I got without this patch:

``` python
Traceback (most recent call last):
  File "/home/lgs/proyectos/personal/yith/yith-library-server/yithlibraryserver/testing.py", line 91, in setUp
    app = main({}, **settings)
  File "/home/lgs/proyectos/personal/yith/yith-library-server/yithlibraryserver/__init__.py", line 126, in main
    config.include('pyramid_sqlalchemy')
  File "/home/lgs/proyectos/personal/yith/py27-server/lib/python2.7/site-packages/pyramid-1.5.4-py2.7.egg/pyramid/config/__init__.py", line 737, in include
    spec = module.__name__ + ':' + c.__name__
  File "build/bdist.linux-x86_64/egg/mock.py", line 660, in __getattr__
    raise AttributeError(name)
AttributeError: __name__
```

I'm using Pyramid 1.5.4, SQLAlchemy 0.9.9 and pyramid_sqlalchemy 1.2.2
