### PR TITLE
Fix #5 issues with session recreated on parametrized tests

### DIFF
--- a/src/pyramid_sqlalchemy/fixtures.py
+++ b/src/pyramid_sqlalchemy/fixtures.py
@@ -15,27 +15,21 @@ DEFAULT_URI = 'sqlite:///'
 
 def pytest_addoption(parser):
     parser.addoption('--sql-url', default=DEFAULT_URI,
-            help='SQLAlchemy Database URL')
+                     help='SQLAlchemy Database URL')
     parser.addoption('--sql-echo', default=False, action='store_true',
-            help='Echo SQL statements to console')
+                     help='Echo SQL statements to console')
 
 
 def pytest_configure(config):
     DatabaseTestCase.db_uri = config.getoption('sql_url')
 
 
-def pytest_generate_tests(metafunc):
-    if 'sqlalchemy_url' in metafunc.fixturenames:
-        metafunc.parametrize('sqlalchemy_url',
-        [metafunc.config.getoption('sql_url')], scope='session')
-    if 'sql_echo' in metafunc.fixturenames:
-        metafunc.parametrize('sql_echo',
-        [metafunc.config.getoption('sql_echo')], scope='session')
-
-
 @pytest.yield_fixture(scope='session')
-def _sqlalchemy(sqlalchemy_url, sql_echo):
-    engine = create_engine(sqlalchemy_url, echo=sql_echo)
+def _sqlalchemy(request):
+
+    engine = create_engine(request.config.option.sql_url,
+                           echo=request.config.option.sql_echo)
+
     if engine.dialect.name == 'sqlite':
         engine.execute('PRAGMA foreign_keys = ON')
     # Check if a previous test has kept a session open. This will silently


### PR DESCRIPTION
After this change, database is not recreated between tests:

```
============================= test session starts ==============================
platform linux2 -- Python 2.7.6, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/joac/other_repos/pyramid_sqlalchemy, inifile: setup.cfg
plugins: pyramid-sqlalchemy-1.5
collected 3 items

test_pytest.py 2016-04-22 11:16:25,491 INFO sqlalchemy.engine.base.Engine SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1
2016-04-22 11:16:25,491 INFO sqlalchemy.engine.base.Engine ()
2016-04-22 11:16:25,491 INFO sqlalchemy.engine.base.Engine SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1
2016-04-22 11:16:25,491 INFO sqlalchemy.engine.base.Engine ()
2016-04-22 11:16:25,492 INFO sqlalchemy.engine.base.Engine PRAGMA foreign_keys = ON
2016-04-22 11:16:25,492 INFO sqlalchemy.engine.base.Engine ()
2016-04-22 11:16:25,492 INFO sqlalchemy.engine.base.Engine PRAGMA table_info("models")
2016-04-22 11:16:25,492 INFO sqlalchemy.engine.base.Engine ()
2016-04-22 11:16:25,493 INFO sqlalchemy.engine.base.Engine 
CREATE TABLE models (
	id INTEGER NOT NULL, 
	PRIMARY KEY (id)
)


2016-04-22 11:16:25,493 INFO sqlalchemy.engine.base.Engine ()
2016-04-22 11:16:25,493 INFO sqlalchemy.engine.base.Engine COMMIT
parameter foo 0
.parameter foo 1
.parameter foo 2
.2016-04-22 11:16:25,496 INFO sqlalchemy.engine.base.Engine PRAGMA table_info("models")
2016-04-22 11:16:25,496 INFO sqlalchemy.engine.base.Engine ()
2016-04-22 11:16:25,497 INFO sqlalchemy.engine.base.Engine 
DROP TABLE models
2016-04-22 11:16:25,497 INFO sqlalchemy.engine.base.Engine ()
2016-04-22 11:16:25,497 INFO sqlalchemy.engine.base.Engine COMMIT


=========================== 3 passed in 0.02 seconds ===========================
```